### PR TITLE
Add cleanup of kubectl context to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,5 @@ kubectl get no
 ## Cleanup
 ```bash
 ansible-playbook 14-cleanup.yml
+kubectl config delete-context kubernetes-the-hard-way
 ```


### PR DESCRIPTION
Add deletion of `kubernetes-the-hard-way` context to cleanup section of README.md.