### PR TITLE
Add ignore_errors to gce_ip module

### DIFF
--- a/14-cleanup.yml
+++ b/14-cleanup.yml
@@ -40,6 +40,7 @@
         name: kubernetes-the-hard-way
         region: us-west1
         state: absent
+      ignore_errors: true
 
     - name: Ensure firewall rules are deleted
       gce_net:


### PR DESCRIPTION
As it isn't idempotent and fails on second run with "Cannot delete unknown address: kubernetes-the-hard-way".

Fixes #5 